### PR TITLE
Apply obj, prop late when emit happens, not during on()

### DIFF
--- a/test/object_listen_test.js
+++ b/test/object_listen_test.js
@@ -129,4 +129,32 @@ describe('object listening', function() {
     assert.equal('oscar', obj.jumpName);
     assert.equal(1, obj.counter);
   });
+
+  it('late apply of method name with removeListener', function() {
+    var obj = {
+      shakeCount: 0,
+      newShakeCount: 0,
+      shake: function() {
+        this.shakeCount += 1;
+      },
+    };
+
+    evt.on('shake', obj, 'shake');
+
+    // Swap out shake definition.
+    obj.shake = function() {
+      this.newShakeCount += 1;
+    };
+
+    evt.emit('shake');
+    evt.emit('shake');
+
+    evt.removeListener('shake', obj, 'shake');
+
+    evt.emit('shake');
+    evt.emit('shake');
+
+    assert.equal(2, obj.newShakeCount);
+    assert.equal(0, obj.shakeCount);
+  });
 });


### PR DESCRIPTION
This allows for the object to vary its definition of the function at the property name after registration with evt. 

This can be useful for subclasses or mixin that might override a function definition, but after the constructor function has registered with evt.on().

r? @asutherland 
