### PR TITLE
Rev to 1.2.0, emit errors are console.logged unless there is a top level error listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,18 @@ An event library with "latest value support, mixin for objects to become event e
 
 Other notes about it:
 
-* The module itself is an event emitter. Useful for "global" pub/sub.
-* evt.mix can be used to mix in an event emitter into existing object.
-* Notification of listeners is done in a try/catch, so all listeners are notified even if one fails. Errors are thrown async via setTimeout so that all the listeners can be notified without escaping from the code via a throw within the listener group notification.
-* New evt.Emitter() can be used to create a new instance of an event emitter.
-* Uses "this" internally, so always call object with the emitter args.
-* Allows passing Object, propertyName for listeners, to allow Object[propertyName].apply(Object, ...) listener calls.
+ * the module itself is an event emitter. Useful for "global" pub/sub.
+ * evt.mix can be used to mix in an event emitter into existing object.
+ * notification of listeners is done in a try/catch, so all listeners
+   are notified even if one fails.
+ * Errors when notifying listeners in emit() are available via
+   evt.emit('error'). If there are no error listeners for 'error', then
+   console.error() is used to log the error with a stack trace.
+ * new evt.Emitter() can be used to create a new instance of an
+   event emitter.
+ * Uses "this" internally, so always call object with the emitter args.
+ * Allows passing Object, propertyName for listeners, to allow
+   Object[propertyName].apply(Object, ...) listener calls.
 
 ## License
 

--- a/evt.js
+++ b/evt.js
@@ -1,5 +1,5 @@
 /*
- * evt, an event lib. Version 1.1.1.
+ * evt, an event lib. Version 1.2.0.
  * Copyright 2013-2015, Mozilla Foundation
  *
  * Notable features:
@@ -7,9 +7,10 @@
  * - the module itself is an event emitter. Useful for "global" pub/sub.
  * - evt.mix can be used to mix in an event emitter into existing object.
  * - notification of listeners is done in a try/catch, so all listeners
- *   are notified even if one fails. Errors are thrown async via setTimeout
- *   so that all the listeners can be notified without escaping from the
- *   code via a throw within the listener group notification.
+ *   are notified even if one fails.
+ * - Errors when notifying listeners in emit() are available via
+ *   evt.emit('error'). If there are no error listeners for 'error', then
+ *   console.error() is used to log the error with a stack trace.
  * - new evt.Emitter() can be used to create a new instance of an
  *   event emitter.
  * - Uses "this" internally, so always call object with the emitter args.
@@ -61,6 +62,16 @@
     var listeners = emitter._events[id];
     if (listeners && !listeners.length) {
       delete emitter._events[id];
+    }
+  }
+
+  // If there is an error listner, delegate to that, otherwise just log the
+  // errors, so that emit notifications to other listeners still work.
+  function emitError(err) {
+    if (evt._events.hasOwnProperty('error')) {
+      evt.emit('error', err);
+    } else {
+      console.error(err, err.stack);
     }
   }
 
@@ -241,15 +252,7 @@
           try {
             callApply(listeners[i], args);
           } catch (e) {
-            // Throw at later turn so that other listeners
-            // can complete. While this messes with the
-            // stack for the error, continued operation is
-            // valued more in this tradeoff.
-            // This also means we do not need to .catch()
-            // for the wrapping promise.
-            setTimeout(function() {
-              throw e;
-            });
+            emitError(e);
           }
 
           // If listener removed itself, set the index back a number, so that

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evt",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Event library with latest value support and object mixins",
   "main": "evt.js",
   "scripts": {

--- a/test/error_test.js
+++ b/test/error_test.js
@@ -1,0 +1,68 @@
+/*jshint node: true */
+/*global describe, it */
+'use strict';
+
+var assert = require('assert'),
+    evt = require('../evt');
+
+describe('evt', function() {
+  describe('#error listener', function() {
+
+    it('top level use', function() {
+      var err,
+          count = 0;
+
+      function onError(e) {
+        err = e;
+      }
+
+      evt.on('error', onError);
+
+      evt.on('testOn', function() {
+        throw new Error('oops');
+      });
+
+      evt.on('testOn', function() {
+        count += 1;
+      });
+
+      evt.emit('testOn');
+
+      assert.equal(count, 1);
+      assert.equal(true, !!err);
+
+      evt.removeListener(onError);
+    });
+
+
+    it('instance level use', function() {
+      var err,
+          count = 0;
+
+      function onError(e) {
+        err = e;
+      }
+
+      evt.on('error', onError);
+
+      var thing = evt.mix({});
+
+
+      thing.on('testOn', function() {
+        throw new Error('oops');
+      });
+
+      thing.on('testOn', function() {
+        count += 1;
+      });
+
+      thing.emit('testOn');
+
+      assert.equal(count, 1);
+      assert.equal(true, !!err);
+
+      evt.removeListener(onError);
+    });
+  });
+
+});


### PR DESCRIPTION
Asking @asutherland for review, if r+ mentioned in the pull request, then I'll merge.
