### PR TITLE
Check param types, based on a local mod from @asutherland

### DIFF
--- a/evt.js
+++ b/evt.js
@@ -43,8 +43,17 @@
   // (Function, undefined) -> (undefined, Function)
   function objFnPair(obj, fn) {
     if (!fn) {
-      fn = obj,
+      fn = obj;
       obj = undefined;
+    }
+
+    var type = typeof fn;
+    if (type === 'string') {
+      if (typeof obj[fn] !== 'function') {
+        throw new Error('Not a method name: ' + fn);
+      }
+    } else if (type !== 'function') {
+      throw new Error('fn is not a string or function: ' + fn);
     }
     return [obj, fn];
   }

--- a/test/error_test.js
+++ b/test/error_test.js
@@ -31,7 +31,7 @@ describe('evt', function() {
       assert.equal(count, 1);
       assert.equal(true, !!err);
 
-      evt.removeListener(onError);
+      evt.removeListener('error', onError);
     });
 
 
@@ -61,7 +61,7 @@ describe('evt', function() {
       assert.equal(count, 1);
       assert.equal(true, !!err);
 
-      evt.removeListener(onError);
+      evt.removeListener('error', onError);
     });
   });
 

--- a/test/type_test.js
+++ b/test/type_test.js
@@ -1,0 +1,77 @@
+/*jshint node: true */
+/*global describe, it */
+'use strict';
+
+var assert = require('assert'),
+    evt = require('../evt');
+
+describe('evt', function() {
+  describe('input type checks', function() {
+
+    function isFnError(e) {
+      return e.toString().indexOf('fn is not a string or function') !== -1;
+    }
+
+    function isMethodError(e) {
+      return e.toString().indexOf('Not a method name') !== -1;
+    }
+
+    it('throws on bad input', function() {
+      var count = 0;
+
+      try {
+        evt.on('testOn', 4);
+      } catch (e) {
+        count += 1;
+        assert.equal(true, isFnError(e));
+      }
+
+      try {
+        evt.once('testOn', null);
+      } catch (e) {
+        count += 1;
+        assert.equal(true, isFnError(e));
+      }
+
+      try {
+        evt.latest('testOn');
+      } catch (e) {
+        count += 1;
+        assert.equal(true, isFnError(e));
+      }
+
+      try {
+        evt.latest('testOn', 'testOn');
+      } catch (e) {
+        count += 1;
+        assert.equal(true,
+          e.toString()
+           .indexOf('Cannot read property \'testOn\' of undefined') !== -1);
+      }
+
+      try {
+        evt.removeListener('testOn', {});
+      } catch (e) {
+        count += 1;
+        assert.equal(true, isFnError(e));
+      }
+
+      try {
+        evt.latestOnce('testOn', {}, 'doesNotExist');
+      } catch (e) {
+        count += 1;
+        assert.equal(true, isMethodError(e));
+      }
+
+      try {
+        evt.latestOnce('testOn', {}, 42);
+      } catch (e) {
+        count += 1;
+        assert.equal(true, isFnError(e));
+      }
+
+      assert.equal(count, 7);
+    });
+  });
+
+});


### PR DESCRIPTION
@asutherland porting your change into the evt.js repo. I went with a typeof check instead of instanceof since that is what I believe is more portable particularly across frames.

On the plus side, the change caught two places in the unit tests where I forgot to pass the right number of args (were just cleanup calls, but still, they were incorrect)!

Asking for review to see if this matches your original intentions.
